### PR TITLE
dependencias de developers

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,16 @@
   "dependencies": {
     "html-webpack-plugin": "^2.28.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "babel-core": "^6.25.0",
+    "babel-loader": "^7.0.0",
+    "css-loader": "^0.28.4",
+    "node-sass": "^4.5.3",
+    "sass-loader": "^6.0.6",
+    "style-loader": "^0.18.2",
+    "webpack": "^2.6.1",
+    "webpack-dev-server": "^2.4.5"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "webpack-dev-server --history-api-fallback",

--- a/package.json
+++ b/package.json
@@ -3,13 +3,12 @@
   "version": "1.0.0",
   "description": "",
   "main": "webpack.config.js",
-  "dependencies": {
-    "html-webpack-plugin": "^2.28.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "babel-core": "^6.25.0",
     "babel-loader": "^7.0.0",
     "css-loader": "^0.28.4",
+    "html-webpack-plugin": "^2.28.0",
     "node-sass": "^4.5.3",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.18.2",


### PR DESCRIPTION
Agregue las dependencias necesarias al package.json.
Hay que tener con100cia con los devs y que lo puedan correr sin tener que instalar dependencias a patin.